### PR TITLE
DOARUN logo links back to / (home)

### DIFF
--- a/src/components/AppHeader/index.tsx
+++ b/src/components/AppHeader/index.tsx
@@ -40,7 +40,9 @@ export const AppHeader: React.FC = (props: any) => {
         <StyledToolbar>
           <Grid container justify="space-between" alignItems="center">
             <Grid item>
+              <Link to="/">
               <img width="160px" src={logo} alt='logo' aria-label="logo" />
+              </Link>
             </Grid>
             <Grid item>
               <Link to="/profile">


### PR DESCRIPTION
When a user clicks on the DOARUN logo, it now takes them back to the leaderboard home screen... because it feels like the right thing to do.